### PR TITLE
Use more robust systemd startup settings

### DIFF
--- a/etc/systemd/system/newrelic-plugin-agent.service
+++ b/etc/systemd/system/newrelic-plugin-agent.service
@@ -3,10 +3,18 @@ Description=newrelic-plugin-agent
 
 [Service]
 Type=forking
+PrivateTmp=yes
 User=newrelic
+Group=newrelic
+PermissionsStartOnly=true
 PIDFile=/var/run/newrelic/newrelic-plugin-agent.pid
+ExecStartPre=/bin/mkdir -p /var/run/newrelic
+ExecStartPre=/bin/rm -f /var/run/newrelic/newrelic-plugin-agent.pid
+ExecStartPre=/bin/chown -R newrelic:newrelic /var/run/newrelic
 ExecStart=/usr/bin/newrelic-plugin-agent -c /etc/newrelic/newrelic-plugin-agent.cfg
 ExecStop=/bin/kill -INT $MAINPID
+Restart=on-abort
 
 [Install]
 WantedBy=multi-user.target
+


### PR DESCRIPTION
Could you take a look at this? I used your systemd config as a baseline but to get things working robustly on reboot the directory must be created with the right permissions, as /var/run is on a tmpfs directory in CentOS 7. Merging this in might get this branch merged upstream more expeditiously.
